### PR TITLE
Change compile target to ES5 for IE support

### DIFF
--- a/tsconfig.json
+++ b/tsconfig.json
@@ -1,7 +1,8 @@
 {
   "compilerOptions": {
-    "target": "es6",
+    "target": "es5",
     "module": "commonjs",
+    "lib": ["es2015"],
     "declaration": true,
     "outDir": "./dist",
     "strict": true,


### PR DESCRIPTION
This resolves issue #8.

Also added the ES2015 `lib` files to resolve the "error TS2304: Cannot find name 'WeakMap'." message I was getting.

I couldn't get the integration tests to run either before or after my changes, but the other tests passed, anyway.